### PR TITLE
fix: Fix visitedQuestions issue

### DIFF
--- a/quiz/public/Database.json
+++ b/quiz/public/Database.json
@@ -433,6 +433,80 @@
             "6x",
             "2x^2 - 6"
          ]
+      },
+      {
+      "level": 2,
+      "topic": "calculus",
+      "q": "What is the limit of (2x^2 + 3x - 2) / (x - 1) as x approaches 1?",
+      "a": "7",
+      "answers": [
+      "7",
+      "5",
+      "3",
+      "Undefined"
+      ]
+      },
+      {
+      "level": 2,
+      "topic": "calculus",
+      "q": "What is the derivative of ln(x) with respect to x?",
+      "a": "1/x",
+      "answers": [
+      "1/x",
+      "x",
+      "e^x",
+      "0"
+      ]
+      },
+      {
+      "level": 2,
+      "topic": "calculus",
+      "q": "What is the integral of 1 / (1 + x^2) with respect to x?",
+      "a": "arctan(x) + C",
+      "answers": [
+      "arctan(x) + C",
+      "ln(x) + C",
+      "cos(x) + C",
+      "sin(x) + C"
+      ]
+      },
+      {
+      "level": 2,
+      "topic": "calculus",
+      "q": "What is the limit of (e^x - 1) / x as x approaches 0?",
+      "a": "1",
+      "answers": [
+      "1",
+      "0",
+      "e",
+      "Undefined"
+      ]
+      },
+      {
+      "level": 2,
+      "topic": "calculus",
+      "q": "What is the second derivative of f(x) = x^4 - 3x^3 + 2x^2 - x + 1?",
+      "a": "12x - 18",
+      "answers": [
+      "12x - 18",
+      "6x^2 - 6x + 2",
+      "4x^3 - 9x^2 + 4x - 1",
+      "2x^2 - 3x"
+      ]
+      },
+      {
+      "level": 2,
+      "topic": "calculus",
+      "q": "What is the area between the curve y = x^2 and the x-axis from x = 0 to x = 2?",
+      "a": "8/3",
+      "answers": [
+      "8/3",
+      "4/3",
+      "2/3",
+      "10/3"
+      ]
       }
+      
+      
    ]
 }

--- a/quiz/src/App.js
+++ b/quiz/src/App.js
@@ -21,7 +21,7 @@ function App() {
         const algebra = data.algebra;
         const calculus = data.calculus;
         // Add the questions together and shuffle them
-        setQuestions(calculus.concat(algebra).sort(() => 0.5 - Math.random()));
+        setQuestions(calculus.concat(algebra ).sort(() => 0.5 - Math.random()));
       })
       .catch((error) => console.error(error));
   }, []);
@@ -41,11 +41,10 @@ function App() {
   const handleNextButtonClick = () => {
     setCount(count + 1);
     update(selectedAnswer);
-    console.log("visitedQuestions:", visitedQuestions.length);
     if (visitedQuestions.length < 10) {
       // Push the current question to the visitedQuestions array
-      setVisitedQuestions([...visitedQuestions, currentQuestion]);
-      console.log("visitedQuestions:", visitedQuestions.length);
+      setVisitedQuestions(previouslyVisitedQuestions => [...previouslyVisitedQuestions, currentQuestion]);
+      console.log("visitedQuestions:", visitedQuestions);
 
       // Find the next question
       const nextQuestion = questions.find((question) => {
@@ -73,15 +72,18 @@ function App() {
       // If the current question is level 5, then the next question must be level 5 and not visited.
       // Else, the next question must be the current level + 1 and not visited.
       if (currentLevel === 5) {
-        return potentialQuestionLevel === 5 && !visitedQuestions.includes(question);
+        
+        console.log("visitedQuestions:", visitedQuestions);
+        console.log("question:", question.q);
+        return potentialQuestionLevel === 5 && !visitedQuestions.map((q) => q.q).includes(question.q);
       } else {
-        return potentialQuestionLevel === currentLevel + 1 && !visitedQuestions.includes(question);
+        return potentialQuestionLevel === currentLevel + 1  && !visitedQuestions.includes(question);
       }
     } else {
       // If the current question is level 1, then the next question must be level 1 and not visited.
       // Else, the next question must be the previous level and not visited.
       if (currentLevel === 1) {
-        return potentialQuestionLevel === 1 && !visitedQuestions.includes(question);
+        return potentialQuestionLevel === 1 && !visitedQuestions.map((q) => q.q).includes(question.q);
       } else {
         return potentialQuestionLevel === currentLevel - 1 && !visitedQuestions.includes(question);
       }
@@ -106,6 +108,7 @@ function App() {
     setTotalPoints(0);
     setCount(0);
     setShowPoints(false);
+    window.location.reload();
   };
 
   if (showPoints) {

--- a/quiz/src/App.js
+++ b/quiz/src/App.js
@@ -87,7 +87,7 @@ function App() {
       // If the current question is level 1, then the next question must be level 1 and not visited.
       // Else, the next question must be the previous level and not visited.
       if (currentLevel === 1) {
-        return potentialQuestionLevel === 1 && !visitedQuestions.current.map((q) => q.q).includes(question.q);
+        return potentialQuestionLevel === 1 && !visitedQuestions.current.includes(question);
       } else {
         // Next question can be either the current level, or the previous level
         return (potentialQuestionLevel === currentLevel - 1 || potentialQuestionLevel === currentLevel) && !visitedQuestions.current.includes(question);


### PR DESCRIPTION
# What

The visitedQuestions array was out of sync with the current view state. On initial load, the visitedQuestions was null, but the currentQuestion was already set. This meant that later on when we checked visitedQuestions to get the next question, it was 1 question behind.

Additionally, `useState` is a function for when you want to render a variable as UI. Both `questions` and `visitedQuestions` are not rendered in UI and only used for the business logic of the app. The problem with this is that if anything (like a `useEffect` read from `questions` or `visitedQuestions`, when we update those variables, the code inside the `useEffect` would run again. Making it a `useRef` instead means the value persists across renders, but doesn't trigger a re-render. We have to use the `.current` property to get the value as a result. (i.e You have to write`visitedQuestions.current` instead of `visitedQuestions` when using a `useRef`)